### PR TITLE
Use proper casing for options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { constantCase } from "change-case"
+import { paramCase } from "change-case"
 import { spawn } from "child_process"
 import debug from "debug"
 import internal from "stream"
@@ -156,7 +156,7 @@ function weasyprint(
 	const args: [string, ...string[]] = [command]
 
 	Object.entries(options).forEach(function parseOption([camelCaseArg, value]) {
-		const arg = constantCase(camelCaseArg)
+		const arg = paramCase(camelCaseArg)
 
 		if (typeof value === "boolean") {
 			if (value) {


### PR DESCRIPTION
The options were using `constant_case` instead of the correct `param-case`. This fixes that issue.

Fixes #1